### PR TITLE
Explicitly set 'no_hosts: True' for container creation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,7 @@
       name: "{{ podman_working_name }}"
       image: "{{ podman_base_image }}:{{podman_base_image_tag }}"
       init: yes
+      no_hosts: True
       command: /usr/bin/sleep infinity
       env: "{{ podman_proxy_env }}"
   delegate_to: "{{ podman_build_host }}"
@@ -69,6 +70,7 @@
     containers.podman.podman_container:
       name: "{{ podman_working_name }}"
       image: "{{ podman_target_name }}_setup:{{ podman_rev }}"
+      no_hosts: True
       command: /usr/sbin/init
       state: started
       env: "{{ podman_proxy_env }}"


### PR DESCRIPTION
Explicitly set 'no_hosts: True' for container creation, otherwise editing /etc/hosts within the container will fail, as podman bind mounts in the host's /etc/hosts similar to /etc/resolv.conf