### PR TITLE
Don't actually need python and python-xml installed as podman_base_pkgs as the initial raw command that installs python deals with this.

### DIFF
--- a/vars/Suse_15.yml
+++ b/vars/Suse_15.yml
@@ -10,6 +10,4 @@ podman_base_pkgs_default:
   - glibc-i18ndata
   - insserv-compat
   - kernel-default
-  - python
-  - python-xml
   - timezone


### PR DESCRIPTION
This drops python (eg. python2) from the base image by default. Ansible was already using python3 by default here.